### PR TITLE
fix error syntax on docker boot

### DIFF
--- a/sql/schema/006_email_indexes.sql
+++ b/sql/schema/006_email_indexes.sql
@@ -5,5 +5,5 @@ CREATE INDEX idx_email ON github_user_rest_id_author_emails (email);
 
 -- +goose Down
 
-DROP INDEX idx_author_email ON commits;
-DROP INDEX idx_email ON github_user_rest_id_author_emails;
+DROP INDEX IF EXISTS idx_author_email;
+DROP INDEX IF EXISTS idx_email;

--- a/sql/schema/007_repo_url_indexes copy.sql
+++ b/sql/schema/007_repo_url_indexes copy.sql
@@ -8,8 +8,8 @@ CREATE INDEX idx_login ON github_users (login);
 
 -- +goose Down
 
-DROP INDEX idx_repo_url ON commits;
-DROP INDEX idx_full_name ON github_repos;
-DROP INDEX idx_url ON repo_urls;
-DROP INDEX idx_rest_id ON github_user_rest_id_author_emails;
-DROP INDEX idx_login ON github_users;
+DROP INDEX IF EXISTS idx_repo_url;
+DROP INDEX IF EXISTS idx_full_name;
+DROP INDEX IF EXISTS idx_url;
+DROP INDEX IF EXISTS idx_rest_id;
+DROP INDEX IF EXISTS idx_login;


### PR DESCRIPTION
Was having an error on docker boot after deleting all containers/images for DRM/Gogitguru
ChatGPT seems to say that specifying the table for DROP INDEX is not needed, and also "IF EXISTS" makes sure it only gets dropped if it's there

![image](https://github.com/OpenQDev/GoGitguru/assets/75732239/748e4e21-3232-4aba-8a73-93cf6becffe8)
